### PR TITLE
Fix: Requests same API twice

### DIFF
--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -21,7 +21,6 @@ const CountryList = () => {
 
   useEffect(() => {
     Promise.all([fetchMeta(), fetchNewsByClass(ALL), fetchStats()]).then((responses) => {
-      console.log(responses);
       const [meta, news, stats] = responses;
       setClasses(meta.classes);
       setCoutries(meta.countries);

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -5,7 +5,6 @@ import Row from 'react-bootstrap/Row';
 import { fetchNewsByClass, fetchMeta, fetchStats } from '../api';
 import Country from './Country';
 import TopicList from './TopicList';
-import Spinner from 'react-bootstrap/Spinner';
 import Loading from './Loading';
 
 const CountryList = () => {

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -34,6 +34,9 @@ const CountryList = () => {
   }, []);
 
   useEffect(() => {
+    if (!isNewsFetched) {
+      return;
+    }
     setNewsFetched(false);
     fetchNewsByClass(selectedClass).then((news) => {
       setNews(news);


### PR DESCRIPTION
## What

Fix bug that client requests `classes/all` API twice when loading index page.

## Others

Remove `console.log` and unnecessary imports.