### PR TITLE
Fix API request behavior

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -13,6 +13,17 @@ export async function fetchNewsByClass(klass, limit) {
   return response.data;
 }
 
+export async function fetchNewsByClassAndCountry(klass, country, offset, limit) {
+  const path= `/classes/${klass}/${country}`;
+  const response = await axios.get(baseUrl + path, {
+    params: {
+      start: offset,
+      limit: limit || 10
+    }
+  })
+  return response.data
+}
+
 export async function fetchMeta() {
   const path = '/meta';
   const response = await axios.get(baseUrl + path);

--- a/src/components/Country.jsx
+++ b/src/components/Country.jsx
@@ -23,14 +23,14 @@ export default ({ title, entries, topic, url, loading, stats, last_update }) => 
           <h6>関連情報</h6>
           {!loading && entries.length === 0 && <div>情報はありません。</div>}
           <div className="scroll">
-            {loading && (
-              <div className="loading"><Loading /></div>
-            )}
             <ul>
               {entries.map((entry, i) => (
                 <Page key={i} entry={entry} topic={topic} />
               ))}
             </ul>
+            {loading && (
+              <div className="loading"><Loading /></div>
+            )}
           </div>
         </Card.Body>
       </Card>
@@ -49,6 +49,7 @@ export default ({ title, entries, topic, url, loading, stats, last_update }) => 
         }
         .scroll {
           display: flex;
+          flex-flow: column nowrap;
           margin: 10px 0;
           height: 300px;
           overflow-y: auto;

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -7,6 +7,9 @@ import Country from './Country';
 import TopicList from './TopicList';
 import Loading from './Loading';
 
+const NEWS_INITIAL = 30;
+const LOAD_MORE_THRESHOLD = 15;
+
 const CountryList = () => {
   const ALL = 'all';
   const [classes, setClasses] = useState([]);
@@ -48,7 +51,7 @@ const CountryList = () => {
 
   function fetchInitialNews() {
     setIsFetchingNews(true);
-    fetchNewsByClass(ALL, 20)
+    fetchNewsByClass(ALL, NEWS_INITIAL)
       .then((news) => {
         setNews(news);
       })
@@ -77,11 +80,11 @@ const CountryList = () => {
     }
     setIsFetchingNews(true)
     const promises = countries
-      .filter((c) => filteredNews[c.country].length < 10)
+      .filter((c) => filteredNews[c.country].length < LOAD_MORE_THRESHOLD)
       .map((c) => {
         const country = c.country;
         const len = filteredNews[country].length;
-        return fetchNewsByClassAndCountry(selectedClass, country, len, 10 - len);
+        return fetchNewsByClassAndCountry(selectedClass, country, len, LOAD_MORE_THRESHOLD - len);
     });
 
     Promise.allSettled(promises)

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -5,7 +5,6 @@ import Row from 'react-bootstrap/Row';
 import { fetchNewsByClass, fetchNewsByClassAndCountry, fetchMeta, fetchStats } from '../api';
 import Country from './Country';
 import TopicList from './TopicList';
-import Spinner from 'react-bootstrap/Spinner';
 import Loading from './Loading';
 
 const CountryList = () => {

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 
-import { fetchNewsByClass, fetchMeta, fetchStats } from '../api';
+import { fetchNewsByClass, fetchNewsByClassAndCountry, fetchMeta, fetchStats } from '../api';
 import Country from './Country';
 import TopicList from './TopicList';
 import Spinner from 'react-bootstrap/Spinner';
@@ -11,42 +11,115 @@ import Loading from './Loading';
 const CountryList = () => {
   const ALL = 'all';
   const [classes, setClasses] = useState([]);
-  const [countries, setCoutries] = useState([]);
+  const [countries, setCountries] = useState([]);
   const [news, setNews] = useState({});
   const [stats, setStats] = useState({});
   const [lastUpdate, setLastUpdate] = useState({});
-  const [isNewsFetched, setNewsFetched] = useState(false);
-  const [isMetaFetched, setMetaFetched] = useState(false);
   const [selectedClass, setSelectedClass] = useState(ALL);
 
-  useEffect(() => {
-    Promise.all([fetchMeta(), fetchNewsByClass(ALL), fetchStats()]).then((responses) => {
-      console.log(responses);
-      const [meta, news, stats] = responses;
+  const [isFetchingMeta, setIsFetchingMeta] = useState(false);
+  const [isFetchingNews, setIsFetchingNews] = useState(false);
+
+  // computed value: filter news by currently selected class.
+  const filteredNews = useMemo(() => {
+    if (selectedClass === ALL) {
+      return news;
+    }
+    let result = {};
+    for (const country of Object.keys(news)) {
+      result[country] = news[country].filter((entry) => entry.classes[selectedClass] === 1);
+    }
+    return result;
+  }, [news, selectedClass]);
+
+  function fetchCountriesAndStats() {
+    setIsFetchingMeta(true);
+    Promise.all([fetchMeta(), fetchStats()])
+      .then((values) => {
+        const [meta, stats] = values;
+        setCountries(meta.countries);
       setClasses(meta.classes);
-      setCoutries(meta.countries);
-      setNews(news);
       setStats(stats.stats);
       setLastUpdate(stats.last_update);
-      setMetaFetched(true);
-      setNewsFetched(true);
+      })
+      .finally(() => {
+        setIsFetchingMeta(false);
+      });
+  }
+
+  function fetchInitialNews() {
+    setIsFetchingNews(true);
+    fetchNewsByClass(ALL, 20)
+      .then((news) => {
+        setNews(news);
+      })
+      .finally(() => {
+        setIsFetchingNews(false);
     });
+  }
+
+  // Run only ones
+  useEffect(() => {
+    fetchCountriesAndStats();
+    fetchInitialNews();
   }, []);
 
-  useEffect(() => {
-    setNewsFetched(false);
-    fetchNewsByClass(selectedClass).then((news) => {
-      setNews(news);
-      setNewsFetched(true);
+  function sortEntriesByTimestamp(entries) {
+    return entries.sort((a, b) => {
+      return Date.parse(b.orig.timestamp) - Date.parse(a.orig.timestamp);
     });
+  }
+
+  // When change class tab, request more news
+  // if the number of filtered news is fewer than 10.
+  useEffect(() => {
+    if(selectedClass === ALL) {
+      return;
+    }
+    setIsFetchingNews(true)
+    const promises = countries
+      .filter((c) => filteredNews[c.country].length < 10)
+      .map((c) => {
+        const country = c.country;
+        const len = filteredNews[country].length;
+        return fetchNewsByClassAndCountry(selectedClass, country, len, 10 - len);
+    });
+
+    Promise.allSettled(promises)
+      .then(results => {
+        let mergedNews = {}
+
+        for (const res of results) {
+          if (res.status === 'rejected') {
+            continue;
+          }
+          const newEntries = res.value;
+          if (newEntries.length === 0) {
+            continue;
+          }
+          const country = newEntries[0].country;
+          const sorted = sortEntriesByTimestamp([...news[country], ...newEntries]);
+          mergedNews[country] = sorted;
+        }
+
+        setNews({
+          ...news,
+          ...mergedNews
+        })
+        setIsFetchingNews(false);
+      })
+
+
   }, [selectedClass]);
 
   return (
     <Container className="mt-3 p-3 border rounded">
       <h4 className="mb-3">各国の情報</h4>
       <TopicList selectedTopic={selectedClass} topics={classes} changeTopic={setSelectedClass} />
-      {!isMetaFetched ? (
-        <div className="text-center"><Loading /></div>
+      {isFetchingMeta ? (
+        <div className="text-center">
+          <Loading />
+        </div>
       ) : (
         <Container>
           <Row>
@@ -57,8 +130,8 @@ const CountryList = () => {
                 last_update={lastUpdate}
                 title={c.name.ja}
                 url={c.representativeSiteUrl}
-                loading={!isNewsFetched}
-                entries={isNewsFetched && news[c.country] ? news[c.country] : []}
+                loading={isFetchingNews}
+                entries={filteredNews[c.country] || []}
                 topic={selectedClass}
               />
             ))}


### PR DESCRIPTION
## What

Fix how the client request the server to get more news to reduce loading time.

## How

Before, client requests all news every time user changes the class tab.
After, the client keeps entries in the state and request more entries if the number of filtered entries is less than 20.
