### PR TITLE
Fix: Error when changing tabs

### DIFF
--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -26,8 +26,9 @@ const CountryList = () => {
   // computed value: filter news by currently selected class.
   const filteredNews = useMemo(() => {
     let result = {};
-    for (const country of Object.keys(news)) {
-      result[country] = news[country].filter((entry) => entry.classes[selectedClass] === 1);
+    for (const c of countries) {
+      const country = c.country
+      result[country] = (news[country] || []).filter((entry) => entry.classes[selectedClass] === 1);
     }
     return result;
   }, [news, selectedClass]);


### PR DESCRIPTION
## What

When change the tab, sometimes error occurs.
Fix this problem.

## How

When there's no news filtered by class and country, `filteredNews` (computed value) returns empty array.  This prevents from accessing to undefined property of the value.