### PR TITLE
Fix "load more"

### DIFF
--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -11,7 +11,6 @@ const CountryList = () => {
   const [topics, setTopics] = useState([]);
   const [countries, setCountries] = useState([]);
   const [news, setNews] = useState({});
-  // const [stats, setStats] = useState({});
   const [selectedTopic, setSelectedTopic] = useState('');
   
   const [isFetchingMeta, setIsFetchingMeta] = useState(false);

--- a/src/components/CountryList.jsx
+++ b/src/components/CountryList.jsx
@@ -20,7 +20,7 @@ const CountryList = () => {
 
   // computed value: filter news by currently selected class.
   const filteredNews = useMemo(() => {
-    return filterNewsByClass(selectedTopic);
+    return news[selectedTopic] || {};
   }, [news, selectedTopic]);
 
   function setLoading(country, bool) {
@@ -31,6 +31,28 @@ const CountryList = () => {
         loading: bool
       }
     }))
+  }
+
+  function setNewsByTopic(newNews, topic) {
+    setNews(prevNews => {
+      return {
+        ...prevNews,
+        [topic]: newNews
+      }
+    })
+  }
+
+  function addNewsByTopicAndCountry(newEntries, topic, country) {
+    setNews(prevNews => {
+      const prevEntries = prevNews[topic]?.[country] || [];
+      return {
+        ...prevNews,
+        [topic]: {
+          ...prevNews[topic],
+          [country]: [...prevEntries, ...newEntries]
+        }
+      }
+    })
   }
 
   function setNoMoreNews(country, topic) {
@@ -66,46 +88,6 @@ const CountryList = () => {
     })
   }
 
-  function filterNewsByClass(topic) {
-    let result = {};
-    for (const country of Object.keys(news)) {
-      result[country] = news[country].filter((entry) => {
-        return !!entry.topics.find(t => t.name === topic)
-      });
-    }
-    return result;
-  }
-
-  function filterUniqueNews(news1, news2) {
-    let result = [...news1]
-    for (const news of news2) {
-      if (news1.filter(n => n.url === news.url).length > 0) {
-        continue
-      }
-      result.push(news);
-    }
-    return result
-  }
-
-  function sortEntriesByTimestamp(entries) {
-    return entries.sort((a, b) => {
-      return Date.parse(b.orig.timestamp) - Date.parse(a.orig.timestamp);
-    });
-  }
-
-  function setNewsWithSortUniq(newEntries) {
-    setNews(prevNews => {
-      let merged = {};
-      const keys = [...Object.keys(prevNews), ...Object.keys(newEntries)];
-      for (const country of keys) {
-        const uniq = filterUniqueNews(prevNews[country] || [], newEntries[country] || []);
-        const sorted = sortEntriesByTimestamp(uniq);
-        merged[country] = sorted;
-      }
-      return merged;
-    });
-  }
-
   async function initialLoad() {
     setIsFetchingMeta(true);
     const metaRes = await fetchMeta();
@@ -114,42 +96,45 @@ const CountryList = () => {
       setLoading(c.country, true);
     }
     setTopics(metaRes.topics);
-    setSelectedTopic(metaRes.topics[0]);
+    const firstTopic = metaRes.topics[0];
+    setSelectedTopic(firstTopic);
     setIsFetchingMeta(false);
-    const firstClassNews = await fetchNewsByClass(metaRes.topics[0], 20);
+    const firstTopicNews = await fetchNewsByClass(firstTopic, 20);
     for (const c of metaRes.countries) {
       const country = c.country
-      if (!firstClassNews[country] || firstClassNews[country].length < 20) {
-        setNoMoreNews(country, metaRes.topics[0]);
+      if (!firstTopicNews[country] || firstTopicNews[country].length < 20) {
+        setNoMoreNews(country, firstTopic);
       }
     }
-    setNews(firstClassNews);
+    setNews({[firstTopic]: firstTopicNews});
     const topicsNum = metaRes.topics.length;
     // fetch other topic news
     const otherClassNews = await Promise.all(metaRes.topics.slice(1, topicsNum).map(c => fetchNewsByClass(c, 20)));
     otherClassNews.forEach((e, i) => {
+      const topic = metaRes.topics[i + 1];
       for (const c of metaRes.countries) {
         const country = c.country;
         if (!e[country] || e[country].length < 20) {
-          setNoMoreNews(country, metaRes.topics[i + 1]);
+          setNoMoreNews(country, topic);
         }
       }
-      setNewsWithSortUniq(e);
+      setNewsByTopic(e, topic);
     })
     setAllCountriesLoading(false);
   }
 
   async function loadMore(c) {
-    if (countriesFetchState[c]?.loading || countriesFetchState[c]?.noMore?.[selectedTopic]) {
+    const topic = selectedTopic;
+    if (countriesFetchState[c]?.loading || countriesFetchState[c]?.noMore?.[topic]) {
       return;
     }
     setLoading(c, true);
     const offset = filteredNews[c] ? filteredNews[c].length : 0;
-    const newEntries = await fetchNewsByClassAndCountry(selectedTopic, c, offset, 10);
+    const newEntries = await fetchNewsByClassAndCountry(topic, c, offset, 10);
     if (newEntries.length < 10) {
-      setNoMoreNews(c, selectedTopic)
+      setNoMoreNews(c, topic)
     }
-    setNewsWithSortUniq({[c]: newEntries});
+    addNewsByTopicAndCountry(newEntries, topic, c);
     setLoading(c, false);
   }
 


### PR DESCRIPTION
## What

Improves the "load more" feature.
Fix an issue where fetching news on another topic does not show news in timestamp order.

## How

We did this by keeping news entries organized by topic (even if they are depulicated).