### PR TITLE
Fix icon description

### DIFF
--- a/src/components/Icons.jsx
+++ b/src/components/Icons.jsx
@@ -1,48 +1,34 @@
 import React from 'react';
 
 export const description = {
-  verified: "人手でカテゴリを検証済みの記事",
-  useful: "役立つ記事（かつ人手でカテゴリを検証済み）",
-  rumor: "デマに関する記事（かつ人手でカテゴリを検証済み）"
+  useful: "役立つ記事",
+  rumor: "デマに関する記事",
+  notVerified: "カテゴリ未検証の記事"
 };
 
-export const Verified = ({size, active}) => (
+const BaseIcon = ({title, color, size}) => (
   <>
-    <i className="material-icons" title={active ? description.verified : ""}>check_circle</i>
+    <i className="material-icons" title={title || ""}>check_circle</i>
     <style jsx>{`
       .material-icons {
         vertical-align: middle;
-        color: ${active ? "green" : "#ccc"};
+        color: ${color || "#ccc"};
         font-size: ${size || "1em"};
       }
     `}</style>
   </>
+)
+
+export const NotVerified = ({size}) => (
+  <BaseIcon title={description.notVerified} size={size} />
 );
 
 
 export const Useful = ({size}) => (
-  <>
-    <i className="material-icons" title={description.useful}>check_circle</i>
-    <style jsx>{`
-      .material-icons {
-        vertical-align: middle;
-        color: #ffca18;
-        font-size: ${size || "1em"};
-      }
-    `}</style>
-  </>
+  <BaseIcon title={description.useful} size={size} color="#ffca18" />
 );
 
 
 export const Rumor = ({size}) => (
-  <>
-    <i className="material-icons" title={description.rumor}>check_circle</i>
-    <style jsx>{`
-      .material-icons {
-        vertical-align: middle;
-        color: #0079c1;
-        font-size: ${size || "1em"};
-      }
-    `}</style>
-  </>
+  <BaseIcon title={description.rumor} size={size} color="#0079c1" />
 );

--- a/src/components/IndicatorLegends.jsx
+++ b/src/components/IndicatorLegends.jsx
@@ -1,16 +1,9 @@
 import React from "react";
-// import ListGroup from "react-bootstrap/ListGroup";
 
 import * as Icons from "./Icons";
 
-// const div = ({ children }) => <div className="text-secondary">{children}</div>;
-
 export default () => (
   <ul>
-    <li>
-      <Icons.Verified active={true} />
-      <div className="text-secondary">{Icons.description.verified}</div>
-    </li>
     <li>
       <Icons.Useful />
       <div className="text-secondary">{Icons.description.useful}</div>
@@ -18,6 +11,10 @@ export default () => (
     <li>
       <Icons.Rumor />
       <div className="text-secondary">{Icons.description.rumor}</div>
+    </li>
+    <li>
+      <Icons.NotVerified />
+      <div className="text-secondary">{Icons.description.notVerified}</div>
     </li>
     <style jsx>{`
       ul {

--- a/src/components/Page.jsx
+++ b/src/components/Page.jsx
@@ -31,7 +31,7 @@ const Page = ({ entry, topic }) => {
               } else if (isUseful) {
                 return (<Icons.Useful />);
               } else {
-                return (<Icons.Verified active={isVerified} />);
+                return (<Icons.NotVerified active={isVerified} />);
               }
             })()
           }


### PR DESCRIPTION
## What

Fix icon description.  Remove verified icon, add not verified icon.  Now verified & not useful news won't show up.

![image](https://user-images.githubusercontent.com/29170100/80601534-e87d9e80-8a68-11ea-8730-bd88a239ae7b.png)
