### PR TITLE
Fix heading overflow on safari

### DIFF
--- a/src/components/Country.jsx
+++ b/src/components/Country.jsx
@@ -76,6 +76,7 @@ const Country = ({ countryId, topic }) => {
           display: flex;
           align-items: flex-end;
           margin-bottom: 5px;
+          flex: 0 0 auto;
         }
         .public-link {
           margin-left: 10px;


### PR DESCRIPTION
## What

Fix css bug in Safari.

<img width="591" alt="スクリーンショット 2020-05-28 12 17 14" src="https://user-images.githubusercontent.com/29170100/83094681-307df880-a0dd-11ea-9241-28fada921443.png">

<img width="591" alt="スクリーンショット 2020-05-28 12 16 37" src="https://user-images.githubusercontent.com/29170100/83094698-37a50680-a0dd-11ea-8386-40d76b9f3932.png">
