### PR TITLE
Remove `Search` pseudo topic in edit form

### DIFF
--- a/src/containers/EditModalContainer.tsx
+++ b/src/containers/EditModalContainer.tsx
@@ -41,7 +41,7 @@ const initializeFormState = (e: Entry | EntryWithSearchSnippet | null): EditForm
     ...state,
     country: e.country,
     flags: { ...state.flags, ...e.flags },
-    topics: Object.keys(e.snippets)
+    topics: Object.keys(e.snippets).filter(topic => topic !== "Search")
   }
 }
 


### PR DESCRIPTION
Submitting `Search` pseudo topic causes error in API.
This PR removes `Search` from form state to prevent submitting the topic to the API.